### PR TITLE
로그인 페이지 만들기

### DIFF
--- a/src/main/java/com/spring/projectboardadmin/config/SecurityConfig.java
+++ b/src/main/java/com/spring/projectboardadmin/config/SecurityConfig.java
@@ -17,6 +17,7 @@ public class SecurityConfig {
                 .authorizeRequests(auth -> auth.anyRequest().permitAll())
                 .formLogin(withDefaults())
                 .logout(logout -> logout.logoutSuccessUrl("/"))
+                .oauth2Login(withDefaults())
                 .build();
     }
 }

--- a/src/main/resources/templates/layouts/layout-header.html
+++ b/src/main/resources/templates/layouts/layout-header.html
@@ -137,6 +137,20 @@
             </li>
             <!-- */-->
 
+            <!--/* 로그인 버튼 */-->
+            <li class="nav-item">
+                <a id="login" class="nav-link" href="#" role="button">
+                    <i class="fas fa-sign-in-alt"></i>
+                </a>
+            </li>
+
+            <!--/* 로그아웃 버튼 */-->
+            <li class="nav-item">
+                <a id="logout" class="nav-link" href="#" role="button">
+                    <i class="fas fa-sign-out-alt"></i>
+                </a>
+            </li>
+
             <!--/* 전체 화면 토글 버튼 */-->
             <li class="nav-item">
                 <a class="nav-link" data-widget="fullscreen" href="#" role="button">

--- a/src/main/resources/templates/layouts/layout-header.th.xml
+++ b/src/main/resources/templates/layouts/layout-header.th.xml
@@ -2,4 +2,6 @@
 <thlogic>
     <attr sel="#header-nav-home" th:href="@{/}" th:text="'Home'" />
     <attr sel="#header-nav-admin-members" th:href="@{/admin/members}" th:text="'Member'" />
+    <attr sel="#login" sec:authorize="!isAuthenticated()" th:href="@{/oauth2/authorization/kakao}" />
+    <attr sel="#logout" sec:authorize="isAuthenticated()" th:href="@{/logout}" />
 </thlogic>


### PR DESCRIPTION
- 헤더 네비게이션 바 레이아웃 템플릿에 Thymeleaf 태그 `sec:authorize` 를 사용하여 인증 상태에 따라 노출되는 로그인, 로그아웃 버튼 추가
- 카카오 로그인 페이지 호출을 위해 Spring Security의 Config에 OAuth 추가 

Closes: #18