### PR TITLE
게시글 관리 페이지 기능 테스트 정의

### DIFF
--- a/src/main/java/com/spring/projectboardadmin/config/BeanConfig.java
+++ b/src/main/java/com/spring/projectboardadmin/config/BeanConfig.java
@@ -1,0 +1,14 @@
+package com.spring.projectboardadmin.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class BeanConfig {
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder.build();
+    }
+}

--- a/src/main/java/com/spring/projectboardadmin/dto/ArticleDto.java
+++ b/src/main/java/com/spring/projectboardadmin/dto/ArticleDto.java
@@ -1,0 +1,24 @@
+package com.spring.projectboardadmin.dto;
+
+import com.spring.projectboardadmin.domain.UserAccount;
+import net.bytebuddy.asm.Advice;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+public record ArticleDto(
+        Long id,
+        UserAccountDto userAccount,
+        String title,
+        String content,
+        Set<String> hashtags,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy) {
+    public static ArticleDto of(Long id, UserAccountDto userAccount, String title, String content, Set<String> hashtags, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new ArticleDto(id, userAccount, title, content, hashtags, createdAt, createdBy, modifiedAt, modifiedBy);
+    }
+
+
+}

--- a/src/main/java/com/spring/projectboardadmin/dto/properties/ProjectProperties.java
+++ b/src/main/java/com/spring/projectboardadmin/dto/properties/ProjectProperties.java
@@ -1,0 +1,16 @@
+package com.spring.projectboardadmin.dto.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+
+@ConfigurationProperties("project")
+public record ProjectProperties(Board board) {
+    /**
+     * 게시판 속성
+     *
+     * @param url 게시판 서비스 호스트
+     */
+    public record Board(String url) {
+
+    }
+}

--- a/src/main/java/com/spring/projectboardadmin/dto/response/ArticleClientResponse.java
+++ b/src/main/java/com/spring/projectboardadmin/dto/response/ArticleClientResponse.java
@@ -1,0 +1,40 @@
+package com.spring.projectboardadmin.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.spring.projectboardadmin.dto.ArticleDto;
+import org.springframework.data.domain.Page;
+
+import javax.persistence.Embedded;
+import java.util.List;
+
+public record ArticleClientResponse(
+        @JsonProperty("_embedded") Embedded embedded,
+        @JsonProperty("page") Page page
+) {
+    public static ArticleClientResponse empty() {
+        return new ArticleClientResponse(
+                new Embedded(List.of()),
+                new Page(1, 0, 1, 0)
+        );
+    }
+
+    public static ArticleClientResponse of(List<ArticleDto> articles) {
+        return new ArticleClientResponse(
+          new Embedded(articles),
+          new Page(articles.size(), articles.size(), 1, 0)
+        );
+    }
+
+    public List<ArticleDto> articles() {
+        return this.embedded().articles();
+    }
+
+    public record Embedded(List<ArticleDto> articles) {}
+
+    public record Page(
+       int size,
+       long totalElements,
+       int totalPages,
+       int number
+    ) {}
+}

--- a/src/main/java/com/spring/projectboardadmin/service/ArticleManagementService.java
+++ b/src/main/java/com/spring/projectboardadmin/service/ArticleManagementService.java
@@ -1,0 +1,21 @@
+package com.spring.projectboardadmin.service;
+
+import com.spring.projectboardadmin.dto.ArticleDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class ArticleManagementService {
+    public List<ArticleDto> getArticles() {
+        return List.of();
+    }
+    public ArticleDto getArticle(int articleIndex, int pageNumber) {
+        return null;
+    }
+    public void deleteArticle(Long articleId) {
+
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,4 @@
-# global debug
 debug: false
-# for actuator
 management.endpoints.web.exposure.include: "*"
 
 server.port: 8081
@@ -8,8 +6,9 @@ server.port: 8081
 logging:
   level:
     com.spring.projectboard: debug
-    org.springframework.web.servlet: debug # response, request debug ? ?? ??
-    org.hibernate.type.descriptor.sql.BasicBinder: trace # jpa ??? query debug ? ?? ??
+    org.springframework.web.servlet: debug
+    org.hibernate.type.descriptor.sql.BasicBinder: trace
+    org.springframework.web.client.RestTemplate: debug
 
 spring:
   devtools.livereload.port: 35730
@@ -19,12 +18,12 @@ spring:
     password: ${LOCAL_DB_PASSWORD}
   jpa:
     open-in-view: false
-    defer-datasource-initialization: true # test? ??? *.sql? ??? ? ?? ?
-    hibernate.ddl-auto: create # ???? DDL?? ???? table? ??
+    defer-datasource-initialization: true
+    hibernate.ddl-auto: create
     show-sql: true
     properties:
-      hibernate.format_sql: true # formatting
-      hibernate.default_batch_fetch_size: 100 #
+      hibernate.format_sql: true
+      hibernate.default_batch_fetch_size: 100
   h2.console.enabled: false # default=false
   sql.init.mode: always
   data.rest:
@@ -36,24 +35,20 @@ spring:
       client:
         registration:
           kakao:
-            # REST API ?
             client-id: ${KAKAO_OAUTH_CLIENT_ID}
-            # ?? > Client Secret ??
             client-secret: ${KAKAO_OAUTH_CLIENT_SECRET}
             authorization-grant-type: authorization_code
             redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
             client-authentication-method: POST
         provider:
           kakao:
-            # https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#request-code
             authorization-uri: https://kauth.kakao.com/oauth/authorize
-            # https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#request-token
             token-uri: https://kauth.kakao.com/oauth/token
-            # https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#req-user-info
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
 
 springdoc.swagger-ui.path: /swagger-ui
+project.board.url: http://localhost:8080
 
 ---
 

--- a/src/test/java/com/spring/projectboardadmin/controller/ArticleManagementControllerTest.java
+++ b/src/test/java/com/spring/projectboardadmin/controller/ArticleManagementControllerTest.java
@@ -1,23 +1,35 @@
 package com.spring.projectboardadmin.controller;
 
 import com.spring.projectboardadmin.config.SecurityConfig;
+import com.spring.projectboardadmin.domain.constant.RoleType;
+import com.spring.projectboardadmin.dto.ArticleDto;
+import com.spring.projectboardadmin.dto.UserAccountDto;
+import com.spring.projectboardadmin.service.ArticleManagementService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@DisplayName("View 컨트롤러 - 게시글 관리")
+@DisplayName("컨트롤러 - 게시글 관리")
 @Import(SecurityConfig.class)
 @WebMvcTest(ArticleManagementController.class)
 class ArticleManagementControllerTest {
     private final MockMvc mvc;
+    @MockBean private ArticleManagementService articleManagementService;
 
     public ArticleManagementControllerTest(@Autowired MockMvc mvc) {
         this.mvc = mvc;
@@ -27,11 +39,76 @@ class ArticleManagementControllerTest {
     @Test
     void requestArticleManagementView() throws Exception {
         // Given
-
+        given(articleManagementService.getArticles()).willReturn(List.of());
         // When & Then
         mvc.perform(get("/management/articles"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-                .andExpect(view().name("management/articles"));
+                .andExpect(view().name("management/articles"))
+                .andExpect(model().attribute("articles", List.of()));
+        then(articleManagementService).should().getArticles();
+    }
+
+    @DisplayName("[data][GET] 게시글 1개 - 정상 호출")
+    @Test
+    void requestArticle() throws Exception {
+        // Given
+        int articleIndex = 0;
+        int pageNumber = 0;
+        Long articleId = 77L;
+        ArticleDto articleDto = createArticleDto("title", "content");
+        given(articleManagementService.getArticle(articleIndex, pageNumber)).willReturn(articleDto);
+        // When & Then
+        mvc.perform(get("/management/articles/detail?articleIndex=" + articleIndex + "&page=" + pageNumber))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(view().name("management/articles/detail?articleIndex=" + articleIndex + "&page=" + pageNumber))
+                .andExpect(jsonPath("$.id").value(articleId))
+                .andExpect(jsonPath("$.title").value(articleDto.title()))
+                .andExpect(jsonPath("$.content").value(articleDto.content()))
+                .andExpect(jsonPath("$.userAccount.nickname").value(articleDto.userAccount().nickname()));
+        then(articleManagementService).should().getArticle(articleIndex, pageNumber);
+    }
+
+    @DisplayName("[view][GET] 게시글 삭제 - 정상 호출")
+    @Test
+    void deleteArticle() throws Exception {
+        // Given
+        Long articleId = 1L;
+        willDoNothing().given(articleManagementService).deleteArticle(articleId);
+        // When&Then
+        mvc.perform(
+                post("/management/articles/" + articleId + "/delete")
+                .with(csrf())
+        )
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/management/articles"))
+                .andExpect(redirectedUrl("/management/articles"));
+        then(articleManagementService).should().deleteArticle(articleId);
+    }
+
+    private ArticleDto createArticleDto(String title, String content) {
+        return ArticleDto.of(
+                1L,
+                createUserAccountDto(),
+                title,
+                content,
+                null,
+                LocalDateTime.now(),
+                "Uno",
+                LocalDateTime.now(),
+                "Uno"
+        );
+    }
+
+    private UserAccountDto createUserAccountDto() {
+        return UserAccountDto.of(
+                "unoTest",
+                "pw",
+                Set.of(RoleType.ADMIN),
+                "uno-test@email.com",
+                "uno-test",
+                "test memo"
+        );
     }
 }

--- a/src/test/java/com/spring/projectboardadmin/service/ArticleManagementServiceTest.java
+++ b/src/test/java/com/spring/projectboardadmin/service/ArticleManagementServiceTest.java
@@ -1,0 +1,171 @@
+package com.spring.projectboardadmin.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spring.projectboardadmin.domain.constant.RoleType;
+import com.spring.projectboardadmin.dto.ArticleDto;
+import com.spring.projectboardadmin.dto.UserAccountDto;
+import com.spring.projectboardadmin.dto.properties.ProjectProperties;
+import com.spring.projectboardadmin.dto.response.ArticleClientResponse;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.autoconfigure.web.client.AutoConfigureWebClient;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+@ActiveProfiles("test")
+@DisplayName("비지니스 로직 - 게시글 관리")
+class ArticleManagementServiceTest {
+
+    @Disabled("실제 API 호출 결과 확인용")
+    @DisplayName("실제 API 호출 테스트")
+    @SpringBootTest
+    @Nested
+    class RealApiTest {
+    private final ArticleManagementService sut;
+
+    public RealApiTest(@Autowired ArticleManagementService sut) {
+        this.sut = sut;
+    }
+
+    @DisplayName("게시글 목록 호출 실제 API")
+    @Test
+    void callingArticlesRealApi() {
+        // Given
+
+        // When
+        List<ArticleDto> result = sut.getArticles();
+        // Then
+        System.out.println(result.stream().findFirst());
+        assertThat(result).isNotNull();
+    }
+}
+
+    @DisplayName("API mocking 테스트")
+    @EnableConfigurationProperties(ProjectProperties.class)
+    @AutoConfigureWebClient(registerRestTemplate = true)
+    @RestClientTest(ArticleManagementService.class)
+    @Nested
+    class restTemplateTest {
+        private final ArticleManagementService sut;
+        private final ProjectProperties projectProperties;
+        private final MockRestServiceServer server;
+        private final ObjectMapper mapper;
+
+        public restTemplateTest(
+                ArticleManagementService sut,
+                ProjectProperties projectProperties,
+                MockRestServiceServer server,
+                ObjectMapper mapper
+        ) {
+            this.sut = sut;
+            this.projectProperties = projectProperties;
+            this.server = server;
+            this.mapper = mapper;
+        }
+
+        @DisplayName("게시글 목록 호출 API")
+        @Test
+        void callingArticlesApi() throws JsonProcessingException {
+            // Given
+            ArticleDto expectedArticle = createArticleDto("제목", "글");
+            ArticleClientResponse expectedResponse = ArticleClientResponse.of(List.of(expectedArticle));
+            server
+                    .expect(requestTo(projectProperties.board().url() + "/api/articles?size=10000"))
+                    .andRespond(withSuccess(
+                            mapper.writeValueAsString(expectedResponse),
+                            MediaType.APPLICATION_JSON
+                    ));
+            // When
+            List<ArticleDto> result = sut.getArticles();
+            // Then
+            assertThat(result).first()
+                    .hasFieldOrPropertyWithValue("id", expectedArticle.id())
+                    .hasFieldOrPropertyWithValue("title", expectedArticle.title())
+                    .hasFieldOrPropertyWithValue("content", expectedArticle.content())
+                    .hasFieldOrPropertyWithValue("userAccount.nickname", expectedArticle.userAccount().nickname());
+            server.verify();
+        }
+
+        @DisplayName("게시글 호출 API")
+        @Test
+        void callingArticleApi() throws JsonProcessingException {
+            // Given
+            int articleIndex = 0;
+            int pageNumber = 0;
+            ArticleDto expectedArticle = createArticleDto("제목", "글");
+            server
+                    .expect(requestTo(projectProperties.board().url() + "/api/articles/detail?articleIndex=" + articleIndex + "&page=" + pageNumber))
+                    .andRespond(withSuccess(
+                            mapper.writeValueAsString(expectedArticle),
+                            MediaType.APPLICATION_JSON
+                    ));
+            // When
+            ArticleDto result = sut.getArticle(articleIndex, pageNumber);
+            // Then
+            assertThat(result)
+                    .hasFieldOrPropertyWithValue("id", expectedArticle.id())
+                    .hasFieldOrPropertyWithValue("title", expectedArticle.title())
+                    .hasFieldOrPropertyWithValue("content", expectedArticle.content())
+                    .hasFieldOrPropertyWithValue("userAccount.nickname", expectedArticle.userAccount().nickname());
+            server.verify();
+        }
+
+        @DisplayName("게시글 삭제 API")
+        @Test
+        void deleteArticleApi() {
+            // Given
+            long articleId = 1L;
+            server
+                    .expect(requestTo(projectProperties.board().url() + "/api/articles/" + articleId + "/delete"))
+                    .andExpect(method(HttpMethod.DELETE))
+                    .andRespond(withSuccess());
+            // When
+            sut.deleteArticle(articleId);
+            // Then
+            server.verify();
+        }
+
+        private ArticleDto createArticleDto(String title, String content) {
+            return ArticleDto.of(
+                    1L,
+                    createUserAccountDto(),
+                    title,
+                    content,
+                    null,
+                    LocalDateTime.now(),
+                    "Uno",
+                    LocalDateTime.now(),
+                    "Uno"
+            );
+        }
+
+        private UserAccountDto createUserAccountDto() {
+            return UserAccountDto.of(
+                    "unoTest",
+                    "pw",
+                    Set.of(RoleType.ADMIN),
+                    "uno-test@email.com",
+                    "uno-test",
+                    "test memo"
+            );
+        }
+    }
+}


### PR DESCRIPTION
- 사용 설정, 게시판 서비스 호스트를 property로 설정
    - 외부 API 통신을 위해 `RestTemplate`을 bean으로 등록
    - 개발 중 `RestTemplate` 요청과 응답을 로그로 관찰하기 위해 로깅 옵션을 추가
    - 게시판 서비스의 API에 접근할 수 있도록 호스트를 property에 추가하여
  유연하게 관리할 수 있도록 함
    - 게시판 서비스 호스트 property에 접근할 수 있는 record 클래스를
  `@ConfigurationProperties` 를 사용하여 추가

- 게시글 관리 비지니스 로직 & 컨트롤러 테스트 작성
    - 게시글 목록, 단일 게시글, 게시글 삭제 기능 테스트 작성

Closes: #20 