### PR TITLE
테이블명 변경: `user_account` -> `admin_account`

### DIFF
--- a/src/main/java/com/spring/projectboardadmin/domain/AdminAccount.java
+++ b/src/main/java/com/spring/projectboardadmin/domain/AdminAccount.java
@@ -22,7 +22,7 @@ import java.util.Set;
         @Index(columnList = "createdBy")
 })
 @Entity
-public class UserAccount extends AuditingFields{
+public class AdminAccount extends AuditingFields{
     @Id
     @Column(length = 50)
     private String userId;
@@ -48,10 +48,10 @@ public class UserAccount extends AuditingFields{
     @Column
     private String memo;
 
-    protected UserAccount() {
+    protected AdminAccount() {
     }
 
-    private UserAccount(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createdBy) {
+    private AdminAccount(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createdBy) {
         this.userId = userId;
         this.userPassword = userPassword;
         this.roleTypes = roleTypes;
@@ -62,12 +62,12 @@ public class UserAccount extends AuditingFields{
         this.modifiedBy = createdBy;
     }
 
-    public static UserAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
-        return UserAccount.of(userId, userPassword, roleTypes, email, nickname, memo, null);
+    public static AdminAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
+        return AdminAccount.of(userId, userPassword, roleTypes, email, nickname, memo, null);
     }
 
-    public static UserAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createdBy) {
-        return new UserAccount(userId, userPassword, roleTypes, email, nickname, memo, createdBy);
+    public static AdminAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createdBy) {
+        return new AdminAccount(userId, userPassword, roleTypes, email, nickname, memo, createdBy);
     }
 
     public void addRoleType(RoleType roleType) {
@@ -85,7 +85,7 @@ public class UserAccount extends AuditingFields{
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof UserAccount that)) return false;
+        if (!(o instanceof AdminAccount that)) return false;
         return this.getUserId() != null && Objects.equals(this.getUserId(), that.getUserId());
     }
 

--- a/src/main/java/com/spring/projectboardadmin/dto/AdminAccountDto.java
+++ b/src/main/java/com/spring/projectboardadmin/dto/AdminAccountDto.java
@@ -1,0 +1,54 @@
+package com.spring.projectboardadmin.dto;
+
+import com.spring.projectboardadmin.domain.AdminAccount;
+import com.spring.projectboardadmin.domain.constant.RoleType;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+public record AdminAccountDto(
+        String userId,
+        String userPassword,
+        Set<RoleType> roleTypes,
+        String email,
+        String nickname,
+        String memo,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy
+) {
+    public static AdminAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new AdminAccountDto(userId, userPassword, roleTypes, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
+    }
+
+    public static AdminAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
+        return AdminAccountDto.of(userId, userPassword, roleTypes, email, nickname, memo, null, null, null, null);
+    }
+
+    public static AdminAccountDto from(AdminAccount adminAccount) {
+        return new AdminAccountDto(
+                adminAccount.getUserId(),
+                adminAccount.getUserPassword(),
+                adminAccount.getRoleTypes(),
+                adminAccount.getEmail(),
+                adminAccount.getNickname(),
+                adminAccount.getMemo(),
+                adminAccount.getCreatedAt(),
+                adminAccount.getCreatedBy(),
+                adminAccount.getModifiedAt(),
+                adminAccount.getModifiedBy()
+        );
+    }
+
+    public AdminAccount toEntity() {
+        return AdminAccount.of(
+                userId,
+                userPassword,
+                roleTypes,
+                email,
+                nickname,
+                memo
+        );
+    }
+}

--- a/src/main/java/com/spring/projectboardadmin/dto/ArticleDto.java
+++ b/src/main/java/com/spring/projectboardadmin/dto/ArticleDto.java
@@ -1,8 +1,5 @@
 package com.spring.projectboardadmin.dto;
 
-import com.spring.projectboardadmin.domain.UserAccount;
-import net.bytebuddy.asm.Advice;
-
 import java.time.LocalDateTime;
 import java.util.Set;
 

--- a/src/main/java/com/spring/projectboardadmin/dto/UserAccountDto.java
+++ b/src/main/java/com/spring/projectboardadmin/dto/UserAccountDto.java
@@ -1,6 +1,6 @@
 package com.spring.projectboardadmin.dto;
 
-import com.spring.projectboardadmin.domain.UserAccount;
+import com.spring.projectboardadmin.domain.AdminAccount;
 import com.spring.projectboardadmin.domain.constant.RoleType;
 
 import java.time.LocalDateTime;
@@ -8,7 +8,6 @@ import java.util.Set;
 
 public record UserAccountDto(
         String userId,
-        String userPassword,
         Set<RoleType> roleTypes,
         String email,
         String nickname,
@@ -18,37 +17,11 @@ public record UserAccountDto(
         LocalDateTime modifiedAt,
         String modifiedBy
 ) {
-    public static UserAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
-        return new UserAccountDto(userId, userPassword, roleTypes, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
+    public static UserAccountDto of(String userId, Set<RoleType> roleTypes, String email, String nickname, String memo, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new UserAccountDto(userId, roleTypes, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
     }
 
-    public static UserAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
-        return UserAccountDto.of(userId, userPassword, roleTypes, email, nickname, memo, null, null, null, null);
-    }
-
-    public static UserAccountDto from(UserAccount userAccount) {
-        return new UserAccountDto(
-                userAccount.getUserId(),
-                userAccount.getUserPassword(),
-                userAccount.getRoleTypes(),
-                userAccount.getEmail(),
-                userAccount.getNickname(),
-                userAccount.getMemo(),
-                userAccount.getCreatedAt(),
-                userAccount.getCreatedBy(),
-                userAccount.getModifiedAt(),
-                userAccount.getModifiedBy()
-        );
-    }
-
-    public UserAccount toEntity() {
-        return UserAccount.of(
-                userId,
-                userPassword,
-                roleTypes,
-                email,
-                nickname,
-                memo
-        );
+    public static UserAccountDto of(String userId, Set<RoleType> roleTypes, String email, String nickname, String memo) {
+        return UserAccountDto.of(userId, roleTypes, email, nickname, memo, null, null, null, null);
     }
 }

--- a/src/main/java/com/spring/projectboardadmin/dto/security/BoardAdminPrincipal.java
+++ b/src/main/java/com/spring/projectboardadmin/dto/security/BoardAdminPrincipal.java
@@ -1,7 +1,7 @@
 package com.spring.projectboardadmin.dto.security;
 
 import com.spring.projectboardadmin.domain.constant.RoleType;
-import com.spring.projectboardadmin.dto.UserAccountDto;
+import com.spring.projectboardadmin.dto.AdminAccountDto;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -39,7 +39,7 @@ public record BoardAdminPrincipal(
         );
     }
 
-    public static BoardAdminPrincipal from(UserAccountDto dto) {
+    public static BoardAdminPrincipal from(AdminAccountDto dto) {
         return BoardAdminPrincipal.of(
                 dto.userId(),
                 dto.userPassword(),
@@ -50,8 +50,8 @@ public record BoardAdminPrincipal(
         );
     }
 
-    public UserAccountDto toDto() {
-        return UserAccountDto.of(
+    public AdminAccountDto toDto() {
+        return AdminAccountDto.of(
               username,
               password,
               authorities.stream().map(GrantedAuthority::getAuthority).map(RoleType::valueOf).collect(Collectors.toUnmodifiableSet()),

--- a/src/main/java/com/spring/projectboardadmin/repository/AdminAccountRepository.java
+++ b/src/main/java/com/spring/projectboardadmin/repository/AdminAccountRepository.java
@@ -1,0 +1,7 @@
+package com.spring.projectboardadmin.repository;
+
+import com.spring.projectboardadmin.domain.AdminAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminAccountRepository extends JpaRepository<AdminAccount, String> {
+}

--- a/src/main/java/com/spring/projectboardadmin/repository/UserAccountRepository.java
+++ b/src/main/java/com/spring/projectboardadmin/repository/UserAccountRepository.java
@@ -1,7 +1,0 @@
-package com.spring.projectboardadmin.repository;
-
-import com.spring.projectboardadmin.domain.UserAccount;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface UserAccountRepository extends JpaRepository<UserAccount, String> {
-}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,5 +1,5 @@
 -- 테스트 계정
-insert into user_account (user_id, user_password, role_types, nickname, email, memo, created_at, created_by, modified_at, modified_by) values
+insert into admin_account (user_id, user_password, role_types, nickname, email, memo, created_at, created_by, modified_at, modified_by) values
 ('joo', '{noop}asdf1234', 'ADMIN', 'joo', 'joo@mail.com', 'I am Joo.', now(), 'joo', now(), 'joo'),
 ('mark', '{noop}asdf1234', 'MANAGER', 'Mark', 'mark@mail.com', 'I am Mark.', now(), 'joo', now(), 'joo'),
 ('susan', '{noop}asdf1234', 'MANAGER,DEVELOPER', 'Susan', 'Susan@mail.com', 'I am Susan.', now(), 'joo', now(), 'joo'),

--- a/src/test/java/com/spring/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
+++ b/src/test/java/com/spring/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
@@ -101,7 +101,6 @@ class ArticleCommentManagementControllerTest {
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
                 "unoTest",
-                "pw",
                 Set.of(RoleType.ADMIN),
                 "uno-test@email.com",
                 "uno-test",

--- a/src/test/java/com/spring/projectboardadmin/controller/ArticleManagementControllerTest.java
+++ b/src/test/java/com/spring/projectboardadmin/controller/ArticleManagementControllerTest.java
@@ -103,7 +103,6 @@ class ArticleManagementControllerTest {
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
                 "unoTest",
-                "pw",
                 Set.of(RoleType.ADMIN),
                 "uno-test@email.com",
                 "uno-test",

--- a/src/test/java/com/spring/projectboardadmin/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/spring/projectboardadmin/repository/JpaRepositoryTest.java
@@ -1,6 +1,6 @@
 package com.spring.projectboardadmin.repository;
 
-import com.spring.projectboardadmin.domain.UserAccount;
+import com.spring.projectboardadmin.domain.AdminAccount;
 import com.spring.projectboardadmin.domain.constant.RoleType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -9,9 +9,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Role;
 import org.springframework.data.domain.AuditorAware;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import java.util.List;
@@ -24,10 +22,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Import(JpaRepositoryTest.TestJpaConfig.class)
 @DataJpaTest
 class JpaRepositoryTest {
-    private final UserAccountRepository userAccountRepository;
+    private final AdminAccountRepository adminAccountRepository;
 
-    public JpaRepositoryTest(@Autowired UserAccountRepository userAccountRepository) {
-        this.userAccountRepository = userAccountRepository;
+    public JpaRepositoryTest(@Autowired AdminAccountRepository adminAccountRepository) {
+        this.adminAccountRepository = adminAccountRepository;
     }
 
     @DisplayName("회원 정보 조회")
@@ -36,33 +34,33 @@ class JpaRepositoryTest {
         // Given
 
         // When
-        List<UserAccount> userAccounts = userAccountRepository.findAll();
+        List<AdminAccount> adminAccounts = adminAccountRepository.findAll();
         // Then
-        assertThat(userAccounts).isNotNull().hasSize(4);
+        assertThat(adminAccounts).isNotNull().hasSize(4);
     }
 
     @DisplayName("회원 정보 추가")
     @Test
     void addUserAccount() {
         // Given
-        long previousCount = userAccountRepository.count();
-        UserAccount userAccount = UserAccount.of("test", "pw", Set.of(RoleType.DEVELOPER), null, null, null);
+        long previousCount = adminAccountRepository.count();
+        AdminAccount adminAccount = AdminAccount.of("test", "pw", Set.of(RoleType.DEVELOPER), null, null, null);
         // When
-        userAccountRepository.save(userAccount);
+        adminAccountRepository.save(adminAccount);
         // Then
-        assertThat(userAccountRepository.count()).isEqualTo(previousCount + 1);
+        assertThat(adminAccountRepository.count()).isEqualTo(previousCount + 1);
     }
 
     @DisplayName("회원 정보 수정")
     @Test
     void updateUserAccount() {
         // Given
-        UserAccount userAccount = userAccountRepository.getReferenceById("joo");
-        userAccount.addRoleType(RoleType.DEVELOPER);
-        userAccount.addRoleTypes(List.of(RoleType.USER, RoleType.USER));
-        userAccount.removeRoleType(RoleType.ADMIN);
+        AdminAccount adminAccount = adminAccountRepository.getReferenceById("joo");
+        adminAccount.addRoleType(RoleType.DEVELOPER);
+        adminAccount.addRoleTypes(List.of(RoleType.USER, RoleType.USER));
+        adminAccount.removeRoleType(RoleType.ADMIN);
         // When
-        UserAccount updatedAccount = userAccountRepository.saveAndFlush(userAccount);
+        AdminAccount updatedAccount = adminAccountRepository.saveAndFlush(adminAccount);
         // Then
         assertThat(updatedAccount)
                 .hasFieldOrPropertyWithValue("userId", "joo")
@@ -73,12 +71,12 @@ class JpaRepositoryTest {
     @Test
     void deleteUserAccount() {
         // Given
-        long previousCount = userAccountRepository.count();
-        UserAccount userAccount = userAccountRepository.getReferenceById("joo");
+        long previousCount = adminAccountRepository.count();
+        AdminAccount adminAccount = adminAccountRepository.getReferenceById("joo");
         // When
-        userAccountRepository.delete(userAccount);
+        adminAccountRepository.delete(adminAccount);
         // Then
-        assertThat(userAccountRepository.count()).isEqualTo(previousCount - 1);
+        assertThat(adminAccountRepository.count()).isEqualTo(previousCount - 1);
     }
 
     @EnableJpaAuditing

--- a/src/test/java/com/spring/projectboardadmin/service/ArticleCommentManagementServiceTest.java
+++ b/src/test/java/com/spring/projectboardadmin/service/ArticleCommentManagementServiceTest.java
@@ -41,7 +41,8 @@ class ArticleCommentManagementServiceTest {
     class RealApiTest {
         private final ArticleCommentManagementService sut;
 
-        public RealApiTest(@Autowired ArticleCommentManagementService sut) {
+        @Autowired
+        public RealApiTest(ArticleCommentManagementService sut) {
             this.sut = sut;
         }
 
@@ -61,7 +62,7 @@ class ArticleCommentManagementServiceTest {
     @DisplayName("API mocking 테스트")
     @EnableConfigurationProperties(ProjectProperties.class)
     @AutoConfigureWebClient(registerRestTemplate = true)
-    @RestClientTest(ArticleManagementService.class)
+    @RestClientTest(ArticleCommentManagementService.class)
     @Nested
     class restTemplateTest {
         private final ArticleCommentManagementService sut;
@@ -69,6 +70,7 @@ class ArticleCommentManagementServiceTest {
         private final MockRestServiceServer server;
         private final ObjectMapper mapper;
 
+        @Autowired
         public restTemplateTest(
                 ArticleCommentManagementService sut,
                 ProjectProperties projectProperties,
@@ -157,7 +159,6 @@ class ArticleCommentManagementServiceTest {
         private UserAccountDto createUserAccountDto() {
             return UserAccountDto.of(
                     "unoTest",
-                    "pw",
                     Set.of(RoleType.ADMIN),
                     "uno-test@email.com",
                     "uno-test",

--- a/src/test/java/com/spring/projectboardadmin/service/ArticleManagementServiceTest.java
+++ b/src/test/java/com/spring/projectboardadmin/service/ArticleManagementServiceTest.java
@@ -41,7 +41,8 @@ class ArticleManagementServiceTest {
     class RealApiTest {
         private final ArticleManagementService sut;
 
-        public RealApiTest(@Autowired ArticleManagementService sut) {
+        @Autowired
+        public RealApiTest(ArticleManagementService sut) {
             this.sut = sut;
         }
 
@@ -57,7 +58,7 @@ class ArticleManagementServiceTest {
             assertThat(result).isNotNull();
         }
     }
-}
+
 
     @DisplayName("API mocking 테스트")
     @EnableConfigurationProperties(ProjectProperties.class)
@@ -70,6 +71,7 @@ class ArticleManagementServiceTest {
         private final MockRestServiceServer server;
         private final ObjectMapper mapper;
 
+        @Autowired
         public restTemplateTest(
                 ArticleManagementService sut,
                 ProjectProperties projectProperties,
@@ -161,7 +163,6 @@ class ArticleManagementServiceTest {
         private UserAccountDto createUserAccountDto() {
             return UserAccountDto.of(
                     "unoTest",
-                    "pw",
                     Set.of(RoleType.ADMIN),
                     "uno-test@email.com",
                     "uno-test",


### PR DESCRIPTION
- 게시판 서비스의 회원 도메인명과의 구분을 명확히하기 위해 어드민 서비스의 회원 테이블명을 변경
    - `user_account` -> `admin_account` 로 어드민 회원 테이블명 변경
    - 게시판 서비스의 회원 password는 받지 않도록 수정
    
- 테스트 수정
    - bracket({}) 잘못된 부분 수정
    - 의존성 `@Autowired` 설정안된 부분 수정 

Closes: #27